### PR TITLE
Fix _navigation undefined if ref is null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ export default class Navigation {
   @observable.ref navigation: NavigationScreenProp<NavigationState> | undefined;
 
   @action.bound createRef(ref: NavigationContainerComponent & { _navigation: NavigationScreenProp<NavigationState> }) {
-    this.navigation = ref._navigation;
+    if(ref){
+      this.navigation = ref._navigation;
+    }
   }
 
   @action.bound dispatch(action: NavigationAction) {


### PR DESCRIPTION
this is to fix the issue of null _navigation I added a value checking before assigning it to a variable to prevent the error from throwing out.